### PR TITLE
Add truncation on DistilBert tokenizer

### DIFF
--- a/src/mozuma/models/sentences/distilbert/pretrained.py
+++ b/src/mozuma/models/sentences/distilbert/pretrained.py
@@ -16,8 +16,10 @@ def torch_distiluse_base_multilingual_v2(
     for more information.
 
     Args:
-        device (torch.device, optional): The PyTorch device to initialise the model weights.
+        device (torch.device, Optional): The PyTorch device to initialise the model weights.
             Defaults to `torch.device("cpu")`.
+        enable_tokenizer_truncation (bool, Optional): Enable positional embeddings
+            truncation with strategy `only_first`. Defaults to `False`.
     """
     return load_pretrained_model(
         DistilUseBaseMultilingualCasedV2Module(*args, **kwargs), training_id="cased-v2"

--- a/tests/models/test_sentences_distilusev2.py
+++ b/tests/models/test_sentences_distilusev2.py
@@ -42,3 +42,21 @@ def test_embeddings(torch_device: torch.device):
         )
 
     np.testing.assert_array_equal(embeddings_provider, embedding_mozuma)
+
+
+def test_distiluse_enable_truncation():
+    """Test that if truncation is enabled, the model can process long text"""
+    # Creating a long text
+    long_text = "Hello world " * 1000
+
+    # Getting the model with truncation
+    model = torch_distiluse_base_multilingual_v2(
+        torch.device("cpu"), enable_tokenizer_truncation=True
+    )
+
+    # Encode the text
+    encoded = model.get_dataset_transforms()[0](long_text)
+    batch_encoded = (encoded[0].unsqueeze(0), encoded[1].unsqueeze(0))
+
+    # Should not raise errors
+    model.forward(batch_encoded)


### PR DESCRIPTION
## Description

Add support to truncate the input text on DistilUse Multilingual models.

## List of changes

- Add a new argument `enable_tokenizer_truncation` to the `TorchDistilBertModule`. This argument is `False` by default and if enabled, it will truncate the positional embeddings by keeping only the begining.

## Test plan

The related test is `test_distiluse_enable_truncation`

## Associated GitHub Issues

- Fixes #197
